### PR TITLE
Adding ability to specify a type converter for a message header

### DIFF
--- a/EasyNetQ.MetaData.Example.Message/EasyNetQ.MetaData.Example.Message.csproj
+++ b/EasyNetQ.MetaData.Example.Message/EasyNetQ.MetaData.Example.Message.csproj
@@ -38,6 +38,7 @@
   <ItemGroup>
     <Compile Include="ExampleEvent.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="SampleDateConverter.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\EasyNetQ.MetaData\EasyNetQ.MetaData.csproj">

--- a/EasyNetQ.MetaData.Example.Message/ExampleEvent.cs
+++ b/EasyNetQ.MetaData.Example.Message/ExampleEvent.cs
@@ -1,5 +1,6 @@
 ﻿namespace EasyNetQ.MetaData.Example.Message {
     using System;
+    using System.ComponentModel;
     using System.Runtime.Serialization;
 
     public class ExampleEvent {
@@ -7,6 +8,9 @@
 
         [MessageHeader("my_custom_header"), IgnoreDataMember]
         public String CustomHeaderValue { get; set; }
+
+        [MessageHeader("my_custom_date_header"), IgnoreDataMember, TypeConverter(typeof(SampleDateConverter))]
+        public DateTime CustomHeaderDateValue { get; set; }
 
         [MessageProperty(Property.ContentType), IgnoreDataMember]
         public String ContentType { get; set; }

--- a/EasyNetQ.MetaData.Example.Message/SampleDateConverter.cs
+++ b/EasyNetQ.MetaData.Example.Message/SampleDateConverter.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Globalization;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace EasyNetQ.MetaData.Example.Message
+{
+    public class SampleDateConverter : TypeConverter
+    {
+        private const String dateFormat = @"yyyy-mm-dd'T'hh:mm:ss.fff";
+
+        public override bool CanConvertFrom(ITypeDescriptorContext context, Type sourceType)
+        {
+            return typeof(string) == sourceType;
+        }
+
+        public override bool CanConvertTo(ITypeDescriptorContext context, Type destinationType)
+        {
+            return typeof(System.DateTime) == destinationType;
+        }
+
+        public override object ConvertFrom(ITypeDescriptorContext context, CultureInfo culture, object value)
+        {
+            DateTime newDate = default(System.DateTime);
+            DateTime.TryParseExact((String)value, dateFormat, null, DateTimeStyles.AssumeLocal, out newDate);
+            return newDate;
+        }
+
+        public override object ConvertTo(ITypeDescriptorContext context, CultureInfo culture, object value, Type destinationType)
+        {
+            DateTime oldDate = (System.DateTime)value;
+            return oldDate.ToString(dateFormat);
+        }
+    }
+}

--- a/EasyNetQ.MetaData/Bindings/HeaderBinding.cs
+++ b/EasyNetQ.MetaData/Bindings/HeaderBinding.cs
@@ -11,8 +11,25 @@
 
         public HeaderBinding(PropertyInfo boundProperty, String headerKey) {
             _boundProperty = boundProperty;
-            _typeConverter = TypeDescriptor.GetConverter(boundProperty.PropertyType);
+            _typeConverter = GetConverter(boundProperty);
             _headerKey     = headerKey;
+        }
+
+        private TypeConverter GetConverter(PropertyInfo boundProperty)
+        {
+            TypeConverter typeConverter;
+            var tcAttr = _boundProperty.GetCustomAttribute<TypeConverterAttribute>();
+            if (tcAttr != null)
+            {
+                var t = Type.GetType(tcAttr.ConverterTypeName);
+                typeConverter = (TypeConverter)Activator.CreateInstance(t);
+            }
+            else
+            {
+                typeConverter = TypeDescriptor.GetConverter(boundProperty.PropertyType);
+            }
+
+            return typeConverter;
         }
 
         public void ToMessageMetaData(Object source, MessageProperties destination) {


### PR DESCRIPTION
Right now if you use a datetime in as a Header, it does not allow you to specify a datetime format.   This will allow you to specify a custom typeconverter which can allow for this.  
