### PR TITLE
EasyNetQ 3.4.0+ compatibility fix

### DIFF
--- a/EasyNetQ.MetaData.Example.Consumer/EasyNetQ.MetaData.Example.Consumer.csproj
+++ b/EasyNetQ.MetaData.Example.Consumer/EasyNetQ.MetaData.Example.Consumer.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="EasyNetQ" Version="3.1.0" />
+    <PackageReference Include="EasyNetQ" Version="3.4.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/EasyNetQ.MetaData.Example.Producer/EasyNetQ.MetaData.Example.Producer.csproj
+++ b/EasyNetQ.MetaData.Example.Producer/EasyNetQ.MetaData.Example.Producer.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="EasyNetQ" Version="3.1.0" />
+    <PackageReference Include="EasyNetQ" Version="3.4.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/EasyNetQ.MetaData/EasyNetQ.MetaData.csproj
+++ b/EasyNetQ.MetaData/EasyNetQ.MetaData.csproj
@@ -29,7 +29,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="EasyNetQ" Version="3.1.0" />
+    <PackageReference Include="EasyNetQ" Version="3.4.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/EasyNetQ.MetaData/MetaDataMessageSerializationStrategy.cs
+++ b/EasyNetQ.MetaData/MetaDataMessageSerializationStrategy.cs
@@ -45,15 +45,6 @@
             return MessageFactory.CreateInstance(messageType, messageBody, properties);
         }
 
-        public IMessage<T> DeserializeMessage<T>(MessageProperties properties, Byte[] body) where T : class {
-            var messageBody = _serializer.BytesToMessage<T>(body);
-
-            _bindingCache.GetOrAdd(typeof(T), ScanForBindings)
-                .ForEach(binding => binding.FromMessageMetaData(properties, messageBody));
-
-            return new Message<T>(messageBody, properties);
-        }
-
         public SerializedMessage SerializeMessage(IMessage message) {
             var messageBody = message.GetBody();
             var messageProperties = message.Properties;
@@ -69,7 +60,7 @@
             if (String.IsNullOrEmpty(messageProperties.CorrelationId))
                 messageProperties.CorrelationId = _correlationIdGenerator.GetCorrelationId();
 
-            var messageBytes = _serializer.MessageToBytes(messageBody);
+            var messageBytes = _serializer.MessageToBytes(message.MessageType, messageBody);
             return new SerializedMessage(messageProperties, messageBytes);
         }
 

--- a/EasyNetQ.MetaData/MetaDataMessageSerializationStrategy.cs
+++ b/EasyNetQ.MetaData/MetaDataMessageSerializationStrategy.cs
@@ -74,14 +74,14 @@
         }
 
         static IEnumerable<IMetaDataBinding> MakeBindings(PropertyInfo property) {
-            var messageHeaderAttribute = property.GetCustomAttribute<MessageHeaderAttribute>();
+            var messageHeaderAttribute = property.GetCustomAttribute<MessageHeaderAttribute>(true);
 
             if (messageHeaderAttribute != null) {
                 yield return new HeaderBinding(property, messageHeaderAttribute.Key);
                 yield break;
             }
 
-            var messagePropertyAttribute = property.GetCustomAttribute<MessagePropertyAttribute>();
+            var messagePropertyAttribute = property.GetCustomAttribute<MessagePropertyAttribute>(true);
 
             if (messagePropertyAttribute != null && _bindingBuilders.ContainsKey(messagePropertyAttribute.Property)) {
                 yield return _bindingBuilders[messagePropertyAttribute.Property].Invoke(property);


### PR DESCRIPTION
[This commit](https://github.com/EasyNetQ/EasyNetQ/commit/6d93be10) removed generic `BytesToMessage` method from `ISerializer`, so using this package with 3.4.0+ EasyNetQ crashes on publish.

Generic `DeserializeMessage<T>` method was [also removed](https://github.com/EasyNetQ/EasyNetQ/commit/9f4247e5) from `IMessageSerializationStrategy` since 3.0.0 so no more used.